### PR TITLE
Change the hashtag styled progress bar to a full-block styled progressbar

### DIFF
--- a/src/handlers/embed.ts
+++ b/src/handlers/embed.ts
@@ -423,7 +423,7 @@ function drawLoadingBarPerc(percentage: number, barLength: number) {
   const progress = Math.round(barLength * percMult);
   const empty = barLength - progress;
 
-  const progressBar = '[`' + '#'.repeat(progress) + ' '.repeat(empty) + '`]';
+  const progressBar = '[`' + '█'.repeat(progress) + ' '.repeat(empty) + '`]';
 
   return `${progressBar} ${percentage.toFixed(2)}%`;
 }


### PR DESCRIPTION
Change the hashtag (#) in Progress bar to a full block character (█) for appearance reasons